### PR TITLE
add GitHub Actions workflow file for Linux, Windows, and macOS CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,47 @@
+name: build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Ubuntu
+            os: ubuntu-latest
+            install_dir: ~/portmidi
+            cmake_extras: -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          - name: macOS
+            os: macos-latest
+            install_dir: ~/portmidi
+            cmake_extras: -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          - name: Windows
+            os: windows-latest
+            install_dir: C:\portmidi
+            cmake_config: --config RelWithDebInfo
+
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Check out Git repository
+      uses: actions/checkout@v2
+    - name: "[Ubuntu] Install dependencies"
+      run: sudo apt install -y libasound2-dev
+      if: runner.os == 'Linux'
+    - name: Configure
+      run: cmake -D CMAKE_INSTALL_PREFIX=${{ matrix.install_dir }} ${{ matrix.cmake_extras }} -S . -B build
+    - name: Build
+      run: cmake --build build ${{ matrix.cmake_config }}
+      env:
+        CMAKE_BUILD_PARALLEL_LEVEL: 2
+    - name: Install
+      run: cmake --install . ${{ matrix.cmake_config }}
+      working-directory: build
+    - name: Upload Build Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.name }} portmidi build
+        path: ${{ matrix.install_dir }}


### PR DESCRIPTION
This will catch build failures without needing to manually test every commit on every OS.