### PR TITLE
add alsa to Requires.private field of pkgconfig file

### DIFF
--- a/packaging/portmidi.pc.in
+++ b/packaging/portmidi.pc.in
@@ -8,3 +8,4 @@ Description: @CMAKE_PROJECT_DESCRIPTION@
 Version: @CMAKE_PROJECT_VERSION@
 Cflags: -I${includedir}
 Libs: -L${libdir} -l@CMAKE_PROJECT_NAME@
+Requires.private: @PKGCONFIG_REQUIRES_PRIVATE@

--- a/pm_common/CMakeLists.txt
+++ b/pm_common/CMakeLists.txt
@@ -109,6 +109,7 @@ elseif(UNIX)
     list(APPEND PM_LIB_PRIVATE_SRC ${PMDIR}/pm_linux/pmlinuxalsa.c)
     set(PM_NEEDED_LIBS ${CMAKE_THREAD_LIBS_INIT} ${ALSA_LIBRARIES} PARENT_SCOPE)
     target_link_libraries(portmidi PRIVATE Threads::Threads ALSA::ALSA)
+    set(PKGCONFIG_REQUIRES_PRIVATE "alsa" PARENT_SCOPE)
   else()
     message(WARNING "No PMALSA, so PortMidi will not use ALSA, "
                     "and will not find or open MIDI devices.")


### PR DESCRIPTION
From
https://people.freedesktop.org/~dbn/pkg-config-guide.html

My library z uses libx internally, but does not expose libx data
types in its public API. What do I put in my z.pc file?

Again, add the module to Requires.private if it supports
pkg-config. In this case, the compiler flags will be emitted
unnecessarily, but it ensures that the linker flags will be present
when linking statically. If libx does not support pkg-config, add
the necessary linker flags to Libs.private.