### PR TITLE
Add option to disable use of static runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ set(LIBRARY_VERSION "${VERSION}")
 
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
+option(PM_USE_STATIC_RUNTIME "Use MSVC static runtime" ON)
+
 # Always build with position-independent code (-fPIC)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 

--- a/pm_common/CMakeLists.txt
+++ b/pm_common/CMakeLists.txt
@@ -123,7 +123,7 @@ elseif(WIN32)
       ${PMDIR}/pm_win/pmwinmm.c)
     set(PM_NEEDED_LIBS winmm PARENT_SCOPE)
     target_link_libraries(portmidi PRIVATE winmm)
-  if(NOT BUILD_SHARED_LIBS)
+  if(NOT BUILD_SHARED_LIBS AND PM_USE_STATIC_RUNTIME)
     # /MDd is multithread debug DLL, /MTd is multithread debug
     # /MD is multithread DLL, /MT is multithread. Change to static:
     include(../pm_win/static.cmake)


### PR DESCRIPTION
With this pull request a new option is added PM_USE_STATIC_RUNTIME that allows disabling the use of the static runtime.
PM_USE_STATIC_RUNTIME defaults to ON

