### PR TITLE
Changing path to pm_common directory in file pm_commom/CMakeLists.txt

### DIFF
--- a/pm_common/CMakeLists.txt
+++ b/pm_common/CMakeLists.txt
@@ -47,7 +47,7 @@ set_target_properties(portmidi PROPERTIES
                       "MultiThreaded$<$<CONFIG:Debug>:Debug>${MSVCRT_DLL}"
                       WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 target_include_directories(portmidi PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/pm_common>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 


### PR DESCRIPTION
Changing the line $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/pm_common> of pm_common/CMakeLists.txt file to $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>.

With previous configuration, the build could not compile correctly because the specified path ${CMAKE_CURRENT_SOURCE_DIR}> points already to the pm_commom/ directory.