### PR TITLE
Add missing return type

### DIFF
--- a/pm_win/pmwinmm.c
+++ b/pm_win/pmwinmm.c
@@ -253,7 +253,7 @@ static unsigned int winmm_check_host_error(PmInternal *midi)
 }
 
 
-static improve_winerr(int pm_hosterror, char *message)
+static void improve_winerr(int pm_hosterror, char *message)
 {
     if (pm_hosterror == MMSYSERR_NOMEM) {
         /* add explanation to Window's confusing error message */


### PR DESCRIPTION
I encountered this error while trying to cross compile (linux to windows):

```
/data/dev/daw-deps/portmidi/pm_win/pmwinmm.c:256:8: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
static improve_winerr(int pm_hosterror, char *message)
~~~~~~ ^
```

This fixes compilation when the compiler enforces C99.