### PR TITLE
Sl1200mk2 patch uint32 t

### DIFF
--- a/pm_common/pmutil.h
+++ b/pm_common/pmutil.h
@@ -58,7 +58,7 @@ typedef void PmQueue;
     a field.  The receiver must acknowlege receipt by zeroing the
     field. The sender will not send more until the field is zeroed.
  */
-PMEXPORT PmQueue *Pm_QueueCreate(long num_msgs, int32_t bytes_per_msg);
+PMEXPORT PmQueue *Pm_QueueCreate(long num_msgs, uint32_t bytes_per_msg);
     
 /** destroy a queue and free its storage. 
 

--- a/pm_common/portmidi.c
+++ b/pm_common/portmidi.c
@@ -536,7 +536,7 @@ PMEXPORT PmError Pm_Terminate(void)
 /*
  * returns number of messages actually read, or error code
  */
-PMEXPORT int Pm_Read(PortMidiStream *stream, PmEvent *buffer, int32_t length)
+PMEXPORT int Pm_Read(PortMidiStream *stream, PmEvent *buffer, uint32_t length)
 {
     PmInternal *midi = (PmInternal *) stream;
     int n = 0;
@@ -617,7 +617,7 @@ static PmError pm_end_sysex(PmInternal *midi)
    write_short, begin_sysex, write_byte, end_sysex, and write_realtime */
 
 PMEXPORT PmError Pm_Write(PortMidiStream *stream, PmEvent *buffer,
-                          int32_t length)
+                          uint32_t length)
 {
     PmInternal *midi = (PmInternal *) stream;
     PmError err = pmNoError;
@@ -869,7 +869,7 @@ PmError pm_create_internal(PmInternal **stream, PmDeviceID device_id,
     if (is_input) {
         midi->latency = 0;  /* unused by input */
         if (buffer_size <= 0) buffer_size = 256; /* default buffer size */
-        midi->queue = Pm_QueueCreate(buffer_size, (int32_t) sizeof(PmEvent));
+        midi->queue = Pm_QueueCreate(buffer_size, (uint32_t) sizeof(PmEvent));
         if (!midi->queue) {
             /* free portMidi data */
             *stream = NULL;

--- a/pm_common/portmidi.h
+++ b/pm_common/portmidi.h
@@ -858,7 +858,7 @@ typedef struct {
     message is not considered to be a "new message" and will be
     flushed as well.
 */
-PMEXPORT int Pm_Read(PortMidiStream *stream, PmEvent *buffer, int32_t length);
+PMEXPORT int Pm_Read(PortMidiStream *stream, PmEvent *buffer, uint32_t length);
 
 /** Test whether input is available.
 
@@ -904,7 +904,7 @@ PMEXPORT PmError Pm_Poll(PortMidiStream *stream);
     as soon as this call returns.
 */
 PMEXPORT PmError Pm_Write(PortMidiStream *stream, PmEvent *buffer,
-                          int32_t length);
+                          uint32_t length);
 
 /** Write a timestamped non-system-exclusive midi message.
 

--- a/pm_common/portmidi.h
+++ b/pm_common/portmidi.h
@@ -754,7 +754,7 @@ PMEXPORT PmError Pm_Synchronize(PortMidiStream* stream);
 /** Extract the 2nd data field (e.g., velocity) from a 32-bit midi message. */
 #define Pm_MessageData2(msg) (((msg) >> 16) & 0xFF)
 
-typedef int32_t PmMessage; /**< @brief see #PmEvent */
+typedef uint32_t PmMessage; /**< @brief see #PmEvent */
 /**
    All midi data comes in the form of PmEvent structures. A sysex
    message is encoded as a sequence of PmEvent structures, with each


### PR DESCRIPTION
This is first step in order to go for Midi2.0 on macOS (where MIDIDestinationCreate() is deprecated starting from macOS11 and MIDIDestinationCreateWithProtocol() is working with MIDIEventList* which encapsulate uint32_t and not int32_t)

does it make sense to you?
best regards,
nicolas