### PR TITLE
Fix pkg-config entry paths

### DIFF
--- a/packaging/portmidi.pc.in
+++ b/packaging/portmidi.pc.in
@@ -1,7 +1,7 @@
 prefix="@CMAKE_INSTALL_PREFIX@"
 exec_prefix="${prefix}"
-libdir="${prefix}/lib"
-includedir="${prefix}/include"
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: @CMAKE_PROJECT_NAME@
 Description: @CMAKE_PROJECT_DESCRIPTION@


### PR DESCRIPTION
Use the values from GNUInstallDirs instead of guessing.