### PR TITLE
Fix functions without prototypes.

### DIFF
--- a/pm_mac/pmmac.c
+++ b/pm_mac/pmmac.c
@@ -18,7 +18,7 @@ non-CoreMIDI devices.
 PmDeviceID pm_default_input_device_id = -1;
 PmDeviceID pm_default_output_device_id = -1;
 
-void pm_init()
+void pm_init(void)
 {
     PmError err = pm_macosxcm_init();
     // this is set when we return to Pm_Initialize, but we need it
@@ -40,15 +40,13 @@ void pm_term(void)
     pm_macosxcm_term();
 }
 
-
-PmDeviceID Pm_GetDefaultInputDeviceID()
+PmDeviceID Pm_GetDefaultInputDeviceID(void) 
 {
     Pm_Initialize();
     return pm_default_input_device_id;
 }
 
-PmDeviceID Pm_GetDefaultOutputDeviceID()
-{
+PmDeviceID Pm_GetDefaultOutputDeviceID(void) {
     Pm_Initialize();
     return pm_default_output_device_id;
 }

--- a/pm_mac/readbinaryplist.c
+++ b/pm_mac/readbinaryplist.c
@@ -155,7 +155,7 @@ static void *allocate(size_t size)
     return result;
 }
 
-void bplist_free_data()
+void bplist_free_data(void)
 {
     while (block_list) {
         void *next = *(void **)block_list;


### PR DESCRIPTION
We should never define a function without a
prototype (like "void function()"), but instead
should always use "void function(void)". This
was causing an error in Clang 15.