### PR TITLE
update version number to (already released) 2.0.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ cmake_policy(SET CMP0091 NEW) # enables MSVC_RUNTIME_LIBRARY target property
 # Versions are now in the form x.y.z
 # Changed 1.0 to 2.0 because API is extended with virtual ports:
 set(SOVERSION "2")
-set(VERSION "2.0.3")
+set(VERSION "2.0.4")
 
 project(portmidi VERSION "${VERSION}"
                  DESCRIPTION "Cross-Platform MIDI IO")


### PR DESCRIPTION
Hi, thank you for this useful library.
I just built it from branch `master`, and when looking at the built files I saw that the version number (reflected in the .pc package-config file) is still "2.0.3", even though 2.0.4 was already released.
(AFAIK dynamic libraries can also hold a version number somewhere for inspection, though I didn't check if CMake does this automatically.)

This PR updates the version number in CMakeLists.txt to 2.0.4. (A quick `grep` didn't find it anywhere else, but maybe I've missed it. The changelog file also doesn't have a corresponding entry yet, fyi.)
Alternatively, you could also jump straight to 2.0.5 I guess, so that it's out of the way for the next release.