### PR TITLE
CMake: Search for Threads in the installed config.

### DIFF
--- a/packaging/PortMidiConfig.cmake.in
+++ b/packaging/PortMidiConfig.cmake.in
@@ -5,6 +5,11 @@ if(UNIX AND NOT APPLE AND NOT HAIKU AND (@LINUX_DEFINES@ MATCHES ".*PMALSA.*"))
   find_dependency(ALSA)
 endif()
 
+if(NOT WIN32)
+  set(THREADS_PREFER_PTHREAD_FLAG ON)
+  find_package(Threads REQUIRED)
+endif()
+
 include("${CMAKE_CURRENT_LIST_DIR}/PortMidiTargets.cmake")
 
 check_required_components(PortMidi)


### PR DESCRIPTION
Attempting to consume `PortMidi` in CMake on platforms linking against `Threads::Threads` currently fails with the following error message:
```
The link interface of target "PortMidi::portmidi" contains:

  Threads::Threads

but the target was not found.
```

This is due to `Threads` not being searched in the installed Config file.
