### PR TITLE
ptlinux portability fixes

### DIFF
--- a/porttime/ptlinux.c
+++ b/porttime/ptlinux.c
@@ -83,14 +83,14 @@ PtError Pt_Start(int resolution, PtCallback *callback, void *userData)
     clock_gettime(CLOCK_MONOTONIC_RAW, &time_offset);
     if (callback) {
         int res;
-        pt_callback_parameters *parms = (pt_callback_parameters *) 
+        pt_callback_parameters *parms = (pt_callback_parameters *)
             malloc(sizeof(pt_callback_parameters));
         if (!parms) return ptInsufficientMemory;
         parms->id = pt_callback_proc_id;
         parms->resolution = resolution;
         parms->callback = callback;
         parms->userData = userData;
-        res = pthread_create(&pt_thread_pid, NULL, 
+        res = pthread_create(&pt_thread_pid, NULL,
                              Pt_CallbackProc, parms);
         if (res != 0) return ptHostError;
         pt_thread_created = TRUE;

--- a/porttime/ptlinux.c
+++ b/porttime/ptlinux.c
@@ -31,11 +31,14 @@ CHANGE LOG
 #include "porttime.h"
 #include "time.h"
 #include "sys/resource.h"
-#include "sys/timeb.h"
 #include "pthread.h"
 
 #define TRUE 1
 #define FALSE 0
+
+#ifndef CLOCK_MONOTONIC_RAW
+#define CLOCK_MONOTONIC_RAW CLOCK_MONOTONIC
+#endif
 
 static int time_started_flag = FALSE;
 static struct timespec time_offset = {0, 0};


### PR DESCRIPTION
`CLOCK_MONOTONIC_RAW` is Linux-specific. The changes make ptlinux.c work on *BSD systems by using `CLOCK_MONOTONIC` if `CLOCK_MONOTONIC_RAW` is not defined. 

(The first commit is just fixing the line endings.)