### PR TITLE
Don't use absolut paths to macOS frameworks

### DIFF
--- a/pm_common/CMakeLists.txt
+++ b/pm_common/CMakeLists.txt
@@ -81,19 +81,24 @@ endif()
 # first include the appropriate system-dependent file:
 if(UNIX AND APPLE)
   set(Threads::Threads "" PARENT_SCOPE)
-  find_library(COREAUDIO_LIBRARY CoreAudio REQUIRED)
-  find_library(COREFOUNDATION_LIBRARY CoreFoundation REQUIRED)
-  find_library(COREMIDI_LIBRARY CoreMIDI REQUIRED)
-  find_library(CORESERVICES_LIBRARY CoreServices REQUIRED)
   set(PM_LIB_PRIVATE_SRC 
       ${PMDIR}/porttime/ptmacosx_mach.c
       ${PMDIR}/pm_mac/pmmac.c
       ${PMDIR}/pm_mac/pmmacosxcm.c)
-  set(PM_NEEDED_LIBS ${CMAKE_THREAD_LIBS_INIT} ${COREAUDIO_LIBRARY}
-      ${COREFOUNDATION_LIBRARY} ${COREMIDI_LIBRARY} ${CORESERVICES_LIBRARY}
+  set(PM_NEEDED_LIBS 
+      ${CMAKE_THREAD_LIBS_INIT}
+      -Wl,-framework,CoreAudio
+      -Wl,-framework,CoreFoundation
+      -Wl,-framework,CoreMidi
+      -Wl,-framework,CoreServices
       PARENT_SCOPE)
-  target_link_libraries(portmidi PRIVATE Threads::Threads ${COREAUDIO_LIBRARY}
-      ${COREFOUNDATION_LIBRARY} ${COREMIDI_LIBRARY} ${CORESERVICES_LIBRARY})
+  target_link_libraries(portmidi PRIVATE
+      Threads::Threads
+      -Wl,-framework,CoreAudio
+      -Wl,-framework,CoreFoundation
+      -Wl,-framework,CoreMidi
+      -Wl,-framework,CoreServices
+  )
   # set to CMake default; is this right?:
   set_target_properties(portmidi PROPERTIES MACOSX_RPATH ON)
 elseif(HAIKU)


### PR DESCRIPTION
This fixes https://github.com/PortMidi/portmidi/issues/56

The failing issue can be seen here: 
https://github.com/daschuer/mixxx/actions/runs/5688916805/job/15419537786
It fails, because it is uses Xcode 13.2 while the portmidi requires a framework with absolute path from XVode 12.4 
```
Check for working C compiler: /Applications/Xcode_13.2.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc - skipped
```
```
2023-07-28T06:28:15.3963980Z ##[warning]/Applications/Xcode_12.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CFBase.h:45:6: warning: '__BIG_ENDIAN__' is not defined, evaluates to 0 [-Wundef]
```

It works after using a vcpkg environment including this patch 
https://github.com/daschuer/mixxx/actions/runs/5689098761/job/15420010526

Note, the Ubuntu runners are failing because the Debian package does not provide the CMake files for config mode. 