### PR TITLE
Add include guards to all headers

### DIFF
--- a/pm_common/pminternal.h
+++ b/pm_common/pminternal.h
@@ -19,6 +19,9 @@
 
 /** @cond INTERNAL - add INTERNAL to Doxygen ENABLED_SECTIONS to include */
 
+#ifndef PORTMIDI_PMINTERNAL_H
+#define PORTMIDI_PMINTERNAL_H
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -185,3 +188,5 @@ void pm_read_short(PmInternal *midi, PmEvent *event);
 #endif
 
 /** @endcond */
+
+#endif // PORTMIDI_PMINTERNAL_H

--- a/pm_common/pmutil.h
+++ b/pm_common/pmutil.h
@@ -9,6 +9,9 @@
     available for other uses.
  */
 
+#ifndef PORTMIDI_PMUTIL_H
+#define PORTMIDI_PMUTIL_H
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
@@ -177,3 +180,5 @@ PMEXPORT PmError Pm_SetOverflow(PmQueue *queue);
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
+
+#endif // PORTMIDI_PMUTIL_H

--- a/pm_common/portmidi.h
+++ b/pm_common/portmidi.h
@@ -1,5 +1,6 @@
-#ifndef PORT_MIDI_H
-#define PORT_MIDI_H
+#ifndef PORTMIDI_PORTMIDI_H
+#define PORTMIDI_PORTMIDI_H
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
@@ -969,4 +970,4 @@ PMEXPORT PmError Pm_WriteSysEx(PortMidiStream *stream, PmTimestamp when,
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
-#endif /* PORT_MIDI_H */
+#endif /* PORTMIDI_PORTMIDI_H */

--- a/pm_linux/pmlinux.h
+++ b/pm_linux/pmlinux.h
@@ -1,5 +1,9 @@
 /* pmlinux.h */
 
+#ifndef PORTMIDI_PMLINUX_H
+#define PORTMIDI_PMLINUX_H
+
 extern PmDeviceID pm_default_input_device_id;
 extern PmDeviceID pm_default_output_device_id;
 
+#endif // PORTMIDI_PMLINUX_H

--- a/pm_linux/pmlinuxalsa.h
+++ b/pm_linux/pmlinuxalsa.h
@@ -1,6 +1,9 @@
 /* pmlinuxalsa.h -- system-specific definitions */
 
+#ifndef PORTMIDI_PMLINUXALSA_H
+#define PORTMIDI_PMLINUXALSA_H
+
 PmError pm_linuxalsa_init(void);
 void pm_linuxalsa_term(void);
 
-
+#endif // PORTMIDI_PMLINUXALSA_H

--- a/pm_linux/pmlinuxnull.h
+++ b/pm_linux/pmlinuxnull.h
@@ -1,6 +1,10 @@
 /* pmlinuxnull.h -- system-specific definitions */
 
+#ifndef PORTMIDI_PMLINUXNULL_H
+#define PORTMIDI_PMLINUXNULL_H
+
 PmError pm_linuxnull_init(void);
 void pm_linuxnull_term(void);
 
+#endif // PORTMIDI_PMLINUXNULL_H
 

--- a/pm_mac/pmmacosxcm.h
+++ b/pm_mac/pmmacosxcm.h
@@ -1,4 +1,9 @@
 /* system-specific definitions */
 
+#ifndef PORTMIDI_PMMACOSXCM_H
+#define PORTMIDI_PMMACOSXCM_H
+
 PmError pm_macosxcm_init(void);
 void pm_macosxcm_term(void);
+
+#endif // PORTMIDI_PMMACOSXCM_H

--- a/pm_win/pmwinmm.h
+++ b/pm_win/pmwinmm.h
@@ -1,5 +1,9 @@
 /* pmwinmm.h -- system-specific definitions for windows multimedia API */
 
+#ifndef PORTMIDI_PMWINMM_H
+#define PORTMIDI_PMWINMM_H
+
 void pm_winmm_init( void );
 void pm_winmm_term( void );
 
+#endif // PORTMIDI_PMWINMM_H

--- a/porttime/porttime.h
+++ b/porttime/porttime.h
@@ -7,6 +7,9 @@
 
 /* Should there be a way to choose the source of time here? */
 
+#ifndef PORTMIDI_PORTTIME_H_
+#define PORTMIDI_PORTTIME_H_
+
 #ifdef WIN32
 #ifndef INT32_DEFINED
 // rather than having users install a special .h file for windows, 
@@ -96,3 +99,5 @@ PMEXPORT void Pt_Sleep(int32_t duration);
 #ifdef __cplusplus
 }
 #endif
+
+#endif // PORTMIDI_PORTTIME_H_


### PR DESCRIPTION
To avoid including headers multiple times, this PR adds include guards to all headers (a standard practice in C/C++).

> [!NOTE]
> The alternative implementation would be to use `#pragma once`, a non-standard, but more concise directive. Since `portmidi.h` already contained an include guard, I went with this option. Let me know which you prefer.