### PR TITLE
Add support for targeting iOS

### DIFF
--- a/pm_mac/pmmacosxcm.c
+++ b/pm_mac/pmmacosxcm.c
@@ -1096,7 +1096,7 @@ static CFStringRef ConnectedEndpointName(MIDIEndpointRef endpoint,
         if (nConnected) {
             const SInt32 *pid = (const SInt32 *)(CFDataGetBytePtr(connections));
             for (i = 0; i < nConnected; ++i, ++pid) {
-                MIDIUniqueID id = EndianS32_BtoN(*pid);
+                MIDIUniqueID id = CFSwapInt32BigToHost(*pid);
                 MIDIObjectRef connObject;
                 MIDIObjectType connObjectType;
                 err = MIDIObjectFindByUniqueID(id, &connObject, 


### PR DESCRIPTION
Since iOS is largely based on the same frameworks as macOS, the changes required to support iOS are minor. It does, however, lack some time-related methods, most notably `CoreAudio/HostTime.h` and the suggested approach appears to be using mach time instead: https://developer.apple.com/library/archive/qa/qa1643/_index.html

With this PR `portmidi` can now be built for iOS simply by changing the `CMAKE_SYSTEM_NAME`:

```sh
cmake -B build -DCMAKE_SYSTEM_NAME=iOS
cmake --build build
```