### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,19 @@ for related code and bindings (although currently, not much is here).
 
 ## Compiling and Using PortMidi
 
-Use CMake (or ccmake) to create a Makefile for Linux/BSD or a 
+Use CMake (or ccmake) to create a Makefile for Linux/BSD or a
 project file for Xcode or MS Visual Studio. Use make or an IDE to compile:
+
+On Linux, you need ALSA.
+
+Ubuntu / Debian:
+`sudo apt install libasound2-dev`
+
+Fedora / Red Hat / CentOS:
+`sudo dnf install alsa-lib-devel`
+
+All:
 ```
-sudo apt install libasound2-dev  # on Linux, you need ALSA
 cd portmidi  # start in the top-level portmidi directory
 ccmake .     # set any options interactively, type c to configure
              # type g to generate a Makefile or IDE project
@@ -44,20 +53,20 @@ PortMidi has some changes in 2021:
 
  - added Pm_CreateVirtualInput() and Pm_CreateVirtualOutput() functions that allow
    applications to create named ports analogous to devices.
-   
+
  - improvements for macOS CoreMIDI include higher data rates for devices, better
    handling of Unicode interface names in addition to virtual device creation.
-   
- - the notion of default devices, Pm_GetDefaultInputDeviceID(), 
+
+ - the notion of default devices, Pm_GetDefaultInputDeviceID(),
    Pm_GetDefaultOutputDeviceID and the PmDefaults program have fallen into disuse
    and are now deprecated.
-   
+
  - Native Interfaces for Python, Java, Go, Rust, Lua and more seem best left
    to individual repos, so support within this repo has been dropped. A Java
    interface is still here and probably usable -- let me know if you need it
-   and/or would like to help bring it up to date. I am happy to help with, 
-   link to, or collaborate in supporting PortMidi for other languages. 
-   
+   and/or would like to help bring it up to date. I am happy to help with,
+   link to, or collaborate in supporting PortMidi for other languages.
+
 For up-to-date PortMidi for languages other than C/C++, check with
 developers. As of 27 Sep 2021, this (and SourceForge) is the only repo with
 the features described above.
@@ -82,7 +91,7 @@ them faster to access and more compact.
 To my knowledge, PortSMF has the most complete and useful handling of MIDI
 tempo tracks. E.g., you can edit notes according to either beat or time, and
 you can edit tempo tracks, for example, flattening the tempo while preserving
-the beat alignment, preserving the real time while changing the tempo or 
+the beat alignment, preserving the real time while changing the tempo or
 stretching the tempo over some interval.
 
 In addition to Standard MIDI Files, PortSMF supports an ASCII representation
@@ -95,11 +104,11 @@ Scorealign used to be part of the PortMedia suite. It is now at the [scorealign 
 Scorealign aligns
 audio-to-audio, audio-to-MIDI or MIDI-to-MIDI using dynamic time warping (DTW)
 of a computed chromagram representation. There are some added smoothing tricks
-to improve performance. This library is written in C and runs substantially 
+to improve performance. This library is written in C and runs substantially
 faster than most other implementations, especially those written in MATLAB,
 due to the core DTW algorithm. Users should be warned that while chromagrams
-are robust features for alignment, they achieve robustness by operating at 
-fairly high granularity, e.g., durations of around 100ms, which limits 
+are robust features for alignment, they achieve robustness by operating at
+fairly high granularity, e.g., durations of around 100ms, which limits
 time precision. Other more recent algorithms can doubtless do better, but
-be cautious of claims, since it all depends on what assumptions you can 
+be cautious of claims, since it all depends on what assumptions you can
 make about the music.


### PR DESCRIPTION
No asound library for fedora, but found the header files in this package.  Also, Shared Object (`so`) files in `alsa-lib`.

Also trailing whitespace trimmed.