### PR TITLE
pm_mac: handle eox even when multiple small messages are part of one packet

### DIFF
--- a/pm_mac/pmmacosxcm.c
+++ b/pm_mac/pmmacosxcm.c
@@ -289,6 +289,7 @@ static void process_packet(MIDIPacket *packet, PmEvent *event,
     unsigned char *cur_packet_data = packet->data;
     while (remaining_length > 0) {
         if (cur_packet_data[0] == MIDI_SYSEX ||
+            cur_packet_data[0] == MIDI_EOX ||
             /* are we in the middle of a sysex message? */
             (info->last_command == 0 &&
              !(cur_packet_data[0] & MIDI_STATUS_MASK))) {
@@ -298,11 +299,6 @@ static void process_packet(MIDIPacket *packet, PmEvent *event,
                                              event->timestamp);
             remaining_length -= amt;
             cur_packet_data += amt;
-        } else if (cur_packet_data[0] == MIDI_EOX) {
-            /* this should never happen, because pm_read_bytes should
-             * get and read all EOX bytes*/
-            midi->sysex_in_progress = FALSE;
-            info->last_command = 0;
         } else if (cur_packet_data[0] & MIDI_STATUS_MASK) {
             /* compute the length of the next (short) msg in packet */
 	    unsigned int cur_message_length = midi_length(cur_packet_data[0]);


### PR DESCRIPTION
during a midi stress tests i noticed that sometimes sysex messages got stuck in PortMidi.
what was specific to the error cases was that there was always a real time event just before the last byte of a sysex message.
ie .   [0xf0, 0x1d, 0x51, 0xf8, 0xf7]

coremidi sends one packet containing 0xf8 and 0xf7 and the old code did not handle that case correctly.
