### PR TITLE
Update to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       run: cmake --install . ${{ matrix.cmake_config }}
       working-directory: build
     - name: Upload Build Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.name }} portmidi build
         path: ${{ matrix.install_dir }}


### PR DESCRIPTION
Currently, CI would fail because `upload-artifact@v2` are deprecated. This PR update to `upload-artifact@v4`