### PR TITLE
Fix compiler errors with stricter settings

### DIFF
--- a/pm_common/pminternal.h
+++ b/pm_common/pminternal.h
@@ -165,9 +165,9 @@ PmTimestamp none_synchronize(PmInternal *midi);
 PmError pm_fail_fn(PmInternal *midi);
 PmError pm_fail_timestamp_fn(PmInternal *midi, PmTimestamp timestamp);
 PmError pm_success_fn(PmInternal *midi);
-PmError pm_add_interf(char *interf, pm_create_fn create_fn,
+PmError pm_add_interf(const char *interf, pm_create_fn create_fn,
                       pm_delete_fn delete_fn);
-PmError pm_add_device(char *interf, const char *name, int is_input,
+PmError pm_add_device(const char *interf, const char *name, int is_input,
                       int is_virtual, void *descriptor, pm_fns_type dictionary);
 void pm_undo_add_device(int id);
 uint32_t pm_read_bytes(PmInternal *midi, const unsigned char *data, int len,

--- a/pm_common/portmidi.c
+++ b/pm_common/portmidi.c
@@ -149,7 +149,7 @@ static int pm_interf_list_len = 0;
  * returns pmInsufficientMemor if interface memory is
  * exceeded, otherwise returns pmNoError.
  */
-PmError pm_add_interf(char *interf, pm_create_fn create_fn,
+PmError pm_add_interf(const char *interf, pm_create_fn create_fn,
                       pm_delete_fn delete_fn)
 {
     if (pm_interf_list_len >= MAX_INTERF) {
@@ -207,7 +207,7 @@ PmError pm_create_virtual(PmInternal *midi, int is_input, const char *interf,
  * device would take the name of an existing device.
  * otherwise returns index (portmidi device_id) of the added device
  */
-PmError pm_add_device(char *interf, const char *name, int is_input, 
+PmError pm_add_device(const char *interf, const char *name, int is_input, 
                 int is_virtual, void *descriptor, pm_fns_type dictionary) {
     /* printf("pm_add_device: %s %s %d %p %p\n",
            interf, name, is_input, descriptor, dictionary); */
@@ -330,7 +330,7 @@ int Pm_FindDevice(char *pattern, int is_input)
     int id = pmNoDevice;
     int i;
     /* first parse pattern into name, interf parts */
-    char *interf_pref = ""; /* initially assume it is not there */
+    const char *interf_pref = ""; /* initially assume it is not there */
     char *name_pref = strstr(pattern, ", ");
 
     if (name_pref) { /* found separator, adjust the pointer */
@@ -879,7 +879,7 @@ PmError pm_create_internal(PmInternal **stream, PmDeviceID device_id,
                            int is_input, int latency, PmTimeProcPtr time_proc,
                            void *time_info, int buffer_size)
 {
-    PmInternal *midi;
+    PmInternal *midi = NULL;
     if (device_id < 0 || device_id >= pm_descriptor_len) {
        return pmInvalidDeviceId;
     }

--- a/pm_linux/pmlinux.c
+++ b/pm_linux/pmlinux.c
@@ -27,7 +27,7 @@
 #error One of PMALSA or PMNULL must be defined
 #endif
 
-void pm_init()
+void pm_init(void)
 {
     /* Note: it is not an error for PMALSA to fail to initialize. 
      * It may be a design error that the client cannot query what subsystems
@@ -52,12 +52,12 @@ void pm_term(void)
     #endif
 }
 
-PmDeviceID Pm_GetDefaultInputDeviceID() { 
+PmDeviceID Pm_GetDefaultInputDeviceID(void) { 
     Pm_Initialize();
     return pm_default_input_device_id; 
 }
 
-PmDeviceID Pm_GetDefaultOutputDeviceID() { 
+PmDeviceID Pm_GetDefaultOutputDeviceID(void) { 
     Pm_Initialize();
     return pm_default_output_device_id; 
 }

--- a/pm_mac/pmmacosxcm.c
+++ b/pm_mac/pmmacosxcm.c
@@ -609,7 +609,7 @@ static PmError midi_abort(PmInternal *midi)
 
 static PmError midi_write_flush(PmInternal *midi, PmTimestamp timestamp)
 {
-    OSStatus macHostError = 0;
+    OSStatus macHostError = noErr;
     coremidi_info_type info = (coremidi_info_type) midi->api_info;
     MIDIEndpointRef endpoint = (MIDIEndpointRef) (intptr_t)
                                pm_descriptors[midi->device_id].descriptor;
@@ -649,7 +649,7 @@ static PmError send_packet(PmInternal *midi, Byte *message,
     info->packet = MIDIPacketListAdd(info->packetList,
                                      sizeof(info->packetBuffer), info->packet,
                                      timestamp, messageLength, message);
-#if LIMIT_SEND_RATE
+#if defined(LIMIT_SEND_RATE) && (LIMIT_SEND_RATE != 0)
     info->byte_count += messageLength;
 #endif
     if (info->packet == NULL) {
@@ -1088,7 +1088,7 @@ PmError pm_macosxcm_init(void)
     ItemCount numInputs, numOutputs, numDevices;
     MIDIEndpointRef endpoint;
     OSStatus macHostError = noErr;
-    char *error_text;
+    const char *error_text;
 
     memset(isIAC, 0, sizeof(isIAC)); /* initialize all FALSE */
 

--- a/pm_sndio/pmsndio.c
+++ b/pm_sndio/pmsndio.c
@@ -35,7 +35,7 @@ struct mio_dev {
 
 static void set_mode(struct mio_dev *, unsigned int);
 
-void pm_init()
+void pm_init(void)
 {
     int i, j, k = 0;
     char devices[][16] = {"midithru", "rmidi", "midi", "snd"};
@@ -80,12 +80,12 @@ void pm_term(void)
     }
 }
 
-PmDeviceID Pm_GetDefaultInputDeviceID() {
+PmDeviceID Pm_GetDefaultInputDeviceID(void) {
     Pm_Initialize();
     return pm_default_input_device_id;
 }
 
-PmDeviceID Pm_GetDefaultOutputDeviceID() {
+PmDeviceID Pm_GetDefaultOutputDeviceID(void) {
     Pm_Initialize();
     return pm_default_output_device_id;
 }

--- a/pm_test/fast.c
+++ b/pm_test/fast.c
@@ -69,7 +69,7 @@ PmTimestamp get_time(void *info)
 }
 
 
-void fast_test()
+void fast_test(void)
 {
     PmStream *midi;
     char line[STRING_MAX];
@@ -170,7 +170,7 @@ void fast_test()
 }
 
 
-void show_usage()
+void show_usage(void)
 {
     printf("Usage: fast [-h] [-l latency] [-r rate] [-d device] [-s dur] "
            "[-n] [-p] [-m]\n"

--- a/pm_test/fastrcv.c
+++ b/pm_test/fastrcv.c
@@ -79,7 +79,7 @@ int get_number(const char *prompt)
 }
 
 
-void fastrcv_test()
+void fastrcv_test(void)
 {
     PmStream * midi;
     PmError status, length;
@@ -177,7 +177,7 @@ void fastrcv_test()
 }
 
 
-void show_usage()
+void show_usage(void)
 {
     printf("Usage: fastrcv [-h] [-v] [-d device], where\n"
            "device is the PortMidi device number,\n"

--- a/pm_test/latency.c
+++ b/pm_test/latency.c
@@ -155,7 +155,7 @@ void pt_callback(PtTimestamp timestamp, void *userData)
 }
 
 
-int main()
+int main(int argc, char *argv[])
 {
     int i;
     int len;

--- a/pm_test/midiclock.c
+++ b/pm_test/midiclock.c
@@ -179,7 +179,7 @@ int get_number(const char *prompt)
 * Effect: print help text
 ****************************************************************************/
 
-private void showhelp()
+private void showhelp(void)
 {
     printf("\n");
     printf("t toggles sending MIDI Time Code (MTC)\n");

--- a/pm_test/midithru.c
+++ b/pm_test/midithru.c
@@ -362,7 +362,7 @@ void initialize(int input, int output, int virtual)
 }
 
 
-void finalize()
+void finalize(void)
 {
     /* the timer thread could be in the middle of accessing PortMidi stuff */
     /* to detect that it is done, we first clear process_midi_exit_flag and

--- a/pm_test/mm.c
+++ b/pm_test/mm.c
@@ -106,7 +106,7 @@ extern  int     abort_flag;
 private    void    mmexit(int code);
 private    void    output(PmMessage data);
 private    int     put_pitch(int p);
-private    void    showhelp();
+private    void    showhelp(void);
 private    void    showbytes(PmMessage data, int len, boolean newline);
 private    void    showstatus(boolean flag);
 private    void    doascii(char c);
@@ -549,7 +549,7 @@ private void showbytes(PmMessage data, int len, boolean newline)
 * Effect: print help text
 ****************************************************************************/
 
-private void showhelp()
+private void showhelp(void)
 {
     printf("\n");
     printf("   Item Reported  Range     Item Reported  Range\n");

--- a/pm_test/multivirtual.c
+++ b/pm_test/multivirtual.c
@@ -176,7 +176,7 @@ void main_test(int num)
 }
 
 
-void show_usage()
+void show_usage(void)
 {
     printf("Usage: multivirtual [-h] [-l latency-in-ms] [n]\n"
            "    -h for this message,\n"

--- a/pm_test/pmlist.c
+++ b/pm_test/pmlist.c
@@ -20,7 +20,7 @@
 
 #define STRING_MAX 80 /* used for console input */
 
-void show_usage()
+void show_usage(void)
 {
     printf("Usage: pmlist [-h]\n        -h means help.\n"
            "    Type return to rescan and list devices, q<ret> to quit\n");

--- a/pm_test/qtest.c
+++ b/pm_test/qtest.c
@@ -44,7 +44,7 @@ int cmp_msg(long msg[], long msg2[], int n, int i)
 }
 
 
-int main()
+int main(int argc, char *argv[])
 {
     int msg_len;
     for (msg_len = 4; msg_len < 100; msg_len += 5) {

--- a/pm_test/recvvirtual.c
+++ b/pm_test/recvvirtual.c
@@ -120,7 +120,7 @@ void main_test_input(int num)
 }
 
 
-void show_usage()
+void show_usage(void)
 {
     printf("Usage: recvvirtual [-h] [-m manufacturer] [-c clientname] "
            "[-p portname] [n]\n"

--- a/pm_test/sendvirtual.c
+++ b/pm_test/sendvirtual.c
@@ -132,7 +132,7 @@ void main_test_output(int num)
 }
 
 
-void show_usage()
+void show_usage(void)
 {
     printf("Usage: sendvirtual [-h] [-l latency-in-ms] [-m manufacturer] "
            "[-c clientname] [-p portname] [n]\n"

--- a/pm_test/sysex.c
+++ b/pm_test/sysex.c
@@ -54,7 +54,7 @@ int get_number(const char *prompt)
 
 /* loopback test -- send/rcv from 2 to 1000 bytes of random midi data */
 /**/
-void loopback_test()
+void loopback_test(void)
 {
     int outp;
     int inp;
@@ -210,7 +210,7 @@ cleanup:
 
 /* send_multiple test -- send many sysex messages */
 /**/
-void send_multiple_test()
+void send_multiple_test(void)
 {
     int outp;
     int length;
@@ -341,7 +341,7 @@ void receive_poll(PtTimestamp timestamp, void *userData)
 
 /* receive_multiple_test -- send/rcv from 2 to 1000 bytes of random midi data */
 /**/
-void receive_multiple_test()
+void receive_multiple_test(void)
 {
     PmError err;
     int inp;
@@ -387,7 +387,7 @@ cleanup:
 #define is_real_time_msg(msg) ((0xF0 & Pm_MessageStatus(msg)) == 0xF8)
 
 
-void receive_sysex()
+void receive_sysex(void)
 {
     char line[80];
     FILE *f;
@@ -448,7 +448,7 @@ void receive_sysex()
 }
 
 
-void send_sysex()
+void send_sysex(void)
 {
     char line[80];
     FILE *f;
@@ -511,7 +511,7 @@ void send_sysex()
 }
 
 
-int main()
+int main(int argc, char *argv[])
 {
     int i;
     

--- a/pm_test/testio.c
+++ b/pm_test/testio.c
@@ -19,7 +19,7 @@ PmSysDepInfo *sysdepinfo = NULL;
 
 /* crash the program to test whether midi ports are closed */
 /**/
-void doSomethingReallyStupid() {
+void doSomethingReallyStupid(void) {
     int * tmp = NULL;
     *tmp = 5;
 }
@@ -27,7 +27,7 @@ void doSomethingReallyStupid() {
 
 /* exit the program without any explicit cleanup */
 /**/
-void doSomethingStupid() {
+void doSomethingStupid(void) {
     assert(0);
 }
 
@@ -289,7 +289,7 @@ void main_test_output(int isochronous_test)
 }
 
 
-void main_test_both()
+void main_test_both(void)
 {
     int i = 0;
     int in, out;
@@ -362,7 +362,7 @@ void main_test_both()
    things happen when messages are not always sent in advance,
    this function allows us to exercise the system and test it.
  */
-void main_test_stream() {
+void main_test_stream(void) {
     PmStream * midi;
     PmEvent buffer[16];
 
@@ -452,7 +452,7 @@ void main_test_stream() {
 }
 
 
-void show_usage()
+void show_usage(void)
 {
     printf("Usage: test [-h] [-l latency-in-ms] [-c clientname] "
            "[-p portname] [-v]\n"

--- a/pm_test/virttest.c
+++ b/pm_test/virttest.c
@@ -111,7 +111,7 @@ void wait_until(PmTimestamp when)
 }
 
 
-void show_usage()
+void show_usage(void)
 {
     printf("Usage: virttest\n"
            "    run two instances to test virtual port create/delete\n");
@@ -165,7 +165,7 @@ void check_ports(int cnt, int in_id, char in_stat,
 }
 
 
-void devices_list()
+void devices_list(void)
 {
     int i;
     for (i = 0; i < Pm_CountDevices(); i++) {
@@ -180,7 +180,7 @@ void devices_list()
 }
 
 
-void test2()
+void test2(void)
 {
     PmStream *out = NULL;
     PmStream *in = NULL;
@@ -251,7 +251,7 @@ void test2()
 
 extern int pm_check_errors;
 
-void test()
+void test(void)
 {
     PmStream *out;
     PmStream *in;

--- a/pm_win/pmwin.c
+++ b/pm_win/pmwin.c
@@ -72,13 +72,13 @@ static PmDeviceID pm_get_default_device_id(int is_input, char *key) {
 }
 
 
-PmDeviceID Pm_GetDefaultInputDeviceID() {
+PmDeviceID Pm_GetDefaultInputDeviceID(void) {
     return pm_get_default_device_id(TRUE, 
            "/P/M_/R/E/C/O/M/M/E/N/D/E/D_/I/N/P/U/T_/D/E/V/I/C/E");
 }
 
 
-PmDeviceID Pm_GetDefaultOutputDeviceID() {
+PmDeviceID Pm_GetDefaultOutputDeviceID(void) {
   return pm_get_default_device_id(FALSE,
           "/P/M_/R/E/C/O/M/M/E/N/D/E/D_/O/U/T/P/U/T_/D/E/V/I/C/E");
 }

--- a/pm_win/pmwinmm.c
+++ b/pm_win/pmwinmm.c
@@ -159,7 +159,7 @@ static void pm_add_device_w(char *api, WCHAR *device_name, int is_input,
 }
 
 
-static void pm_winmm_general_inputs()
+static void pm_winmm_general_inputs(void)
 {
     UINT i;
     WORD wRtn;
@@ -185,7 +185,7 @@ static void pm_winmm_general_inputs()
 }
 
 
-static void pm_winmm_mapper_input()
+static void pm_winmm_mapper_input(void)
 {
     WORD wRtn;
     /* Note: if MIDIMAPPER opened as input (documentation implies you
@@ -203,7 +203,7 @@ static void pm_winmm_mapper_input()
 }
 
 
-static void pm_winmm_general_outputs()
+static void pm_winmm_general_outputs(void)
 {
     UINT i;
     DWORD wRtn;
@@ -226,7 +226,7 @@ static void pm_winmm_general_outputs()
 }
 
 
-static void pm_winmm_mapper_output()
+static void pm_winmm_mapper_output(void)
 {
     WORD wRtn;
     /* Note: if MIDIMAPPER opened as output (pseudo MIDI device
@@ -387,7 +387,7 @@ static unsigned int allocate_input_buffer(HMIDIIN h, long buffer_len)
 }
 
 
-static winmm_info_type winmm_info_create()
+static winmm_info_type winmm_info_create(void)
 {
     winmm_info_type info = (winmm_info_type) pm_alloc(sizeof(winmm_info_node));
     info->handle.in = NULL;
@@ -427,7 +427,7 @@ static void report_hosterror(LPWCH error_msg)
 }
 
 
-static void report_hosterror_in()
+static void report_hosterror_in(void)
 {
     WCHAR error_msg[PM_HOST_ERROR_MSG_LEN];
     int err = midiInGetErrorText(pm_hosterror, error_msg,
@@ -437,7 +437,7 @@ static void report_hosterror_in()
 }
 
 
-static void report_hosterror_out()
+static void report_hosterror_out(void)
 {
     WCHAR error_msg[PM_HOST_ERROR_MSG_LEN];
     int err = midiOutGetErrorText(pm_hosterror, error_msg,

--- a/porttime/ptlinux.c
+++ b/porttime/ptlinux.c
@@ -103,7 +103,7 @@ PtError Pt_Start(int resolution, PtCallback *callback, void *userData)
 }
 
 
-PtError Pt_Stop()
+PtError Pt_Stop(void)
 {
     /* printf("Pt_Stop called\n"); */
     pt_callback_proc_id++;
@@ -116,13 +116,13 @@ PtError Pt_Stop()
 }
 
 
-int Pt_Started()
+int Pt_Started(void)
 {
     return time_started_flag;
 }
 
 
-PtTimestamp Pt_Time()
+PtTimestamp Pt_Time(void)
 {
     long seconds, ms;
     struct timespec now;

--- a/porttime/ptmacosx_cf.c
+++ b/porttime/ptmacosx_cf.c
@@ -111,7 +111,7 @@ PtError Pt_Start(int resolution, PtCallback *callback, void *userData)
 }
 
 
-PtError Pt_Stop()
+PtError Pt_Stop(void)
 {
     printf("Pt_Stop called\n");
 
@@ -121,13 +121,13 @@ PtError Pt_Stop()
 }
 
 
-int Pt_Started()
+int Pt_Started(void)
 {
     return time_started_flag;
 }
 
 
-PtTimestamp Pt_Time()
+PtTimestamp Pt_Time(void)
 {
     CFAbsoluteTime now = CFAbsoluteTimeGetCurrent();
     return (PtTimestamp) ((now - startTime) * 1000.0);

--- a/porttime/ptwinmm.c
+++ b/porttime/ptwinmm.c
@@ -38,7 +38,7 @@ PMEXPORT PtError Pt_Start(int resolution, PtCallback *callback, void *userData)
 }
 
 
-PMEXPORT PtError Pt_Stop()
+PMEXPORT PtError Pt_Stop(void)
 {
     if (!time_started_flag) return ptAlreadyStopped;
     if (time_callback && timer_id) {
@@ -52,13 +52,13 @@ PMEXPORT PtError Pt_Stop()
 }
 
 
-PMEXPORT int Pt_Started()
+PMEXPORT int Pt_Started(void)
 {
     return time_started_flag;
 }
 
 
-PMEXPORT PtTimestamp Pt_Time()
+PMEXPORT PtTimestamp Pt_Time(void)
 {
     return timeGetTime() - time_offset;
 }


### PR DESCRIPTION
This fixes a number of cases of the following kinds of compiler errors:

* Strict prototypes
* Ignoring const qualifier
* Uninitialised variables
* Undefined macros