### PR TITLE
Correct return value documentation for Pm_Write

### DIFF
--- a/pm_common/portmidi.h
+++ b/pm_common/portmidi.h
@@ -904,7 +904,7 @@ PMEXPORT PmError Pm_Poll(PortMidiStream *stream);
 
     @param length the length of the \p buffer.
 
-    @return TRUE, FALSE, or an error value.
+    @return #pmNoError or an error code.
 
     \b buffer may contain:
         - short messages 


### PR DESCRIPTION
I assume this is a typo or relic? There's no indication of what TRUE or FALSE would signify here, and I don't think `Pm_Write` ever returns TRUE.