### PR TITLE
Generate doxygen documentation with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,25 @@ INSTALL(FILES
   porttime/porttime.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
+# Documentation
+option(BUILD_DOC "Build documentation" OFF)
+if(BUILD_DOC)
+  find_package(Doxygen)
+  if (NOT DOXYGEN_FOUND)
+    message(ERROR "Doxygen is needed to build the documentation")
+  endif()
+
+  set(DOXYFILE_IN ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in)
+  set(DOXYFILE_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
+  configure_file(${DOXYFILE_IN} ${DOXYFILE_OUT} @ONLY)
+
+  add_custom_target(doc ALL
+    COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYFILE_OUT}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    COMMENT "Generating API documentation with Doxygen"
+    VERBATIM )
+endif (BUILD_DOC)
+
 # pkgconfig - generate pc file
 # See https://cmake.org/cmake/help/latest/command/configure_file.html
 if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -48,7 +48,7 @@ PROJECT_NAME           = PortMidi
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         =
+PROJECT_NUMBER         = @PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewers a
@@ -61,7 +61,7 @@ PROJECT_BRIEF          = "Cross-platform MIDI IO library"
 # pixels and the maximum width should not exceed 200 pixels. Doxygen will copy
 # the logo to the output directory.
 
-PROJECT_LOGO           = portmusic_logo.png
+PROJECT_LOGO           = @CMAKE_CURRENT_SOURCE_DIR@/portmusic_logo.png
 
 # With the PROJECT_ICON tag one can specify an icon that is included in the tabs
 # when the HTML document is shown. Doxygen will copy the logo to the output
@@ -74,7 +74,7 @@ PROJECT_ICON           =
 # entered, it will be relative to the location where Doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = ../github-portmidi-portmidi_docs
+OUTPUT_DIRECTORY       = @CMAKE_CURRENT_BINARY_DIR@
 
 # If the CREATE_SUBDIRS tag is set to YES then Doxygen will create up to 4096
 # sub-directories (in 2 levels) under the output directory of each output format
@@ -190,7 +190,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where Doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        =
+STRIP_FROM_PATH        = @CMAKE_CURRENT_SOURCE_DIR@
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -991,9 +991,9 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = pm_common \
-                         porttime/porttime.h \
-                         pm_common/pmutil.h
+INPUT                  = @CMAKE_CURRENT_SOURCE_DIR@/pm_common/portmidi.h \
+                         @CMAKE_CURRENT_SOURCE_DIR@/pm_common/pmutil.h \
+                         @CMAKE_CURRENT_SOURCE_DIR@/porttime/porttime.h
 
 # This tag can be used to specify the character encoding of the source files
 # that Doxygen parses. Internally Doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
This allows generating the doxygen documentation using CMake.
Building the documentation is not enabled by default, but can be enabled with the BUILD_DOC option:
```
mkdir build
cd build
cmake -DBUILD_DOC=ON ..
make
```

The resulting documentation will end up in a directory called "docs/". It will not be installed with `make install`.

Note that the documentation is built from the following headers only:
```
pm_common/portmidi.h
pm_common/pmutil.h
porttime/porttime.h
```
Are there other files that need to be included?