### PR TITLE
Use find_dependency(Threads)

### DIFF
--- a/packaging/PortMidiConfig.cmake.in
+++ b/packaging/PortMidiConfig.cmake.in
@@ -1,6 +1,14 @@
 @PACKAGE_INIT@
 
+# The imported target's INTERFACE_LINK_LIBRARIES property contains targets
+# provided by other CMake packages. Finding these dependencies is necessary
+# for this config to be actually usable and selected, but they must not be
+# looked with the REQUIRED keyword because this would raise an immediate error
+# also when the user wants CMake to continue (other locations, custom script).
+# https://cmake.org/cmake/help/latest/module/CMakeFindDependencyMacro.html
+
 include(CMakeFindDependencyMacro)
+
 if(UNIX AND NOT APPLE AND NOT HAIKU AND (@LINUX_DEFINES@ MATCHES ".*PMALSA.*"))
   find_dependency(ALSA)
 endif()

--- a/packaging/PortMidiConfig.cmake.in
+++ b/packaging/PortMidiConfig.cmake.in
@@ -7,7 +7,7 @@ endif()
 
 if(NOT WIN32)
   set(THREADS_PREFER_PTHREAD_FLAG ON)
-  find_package(Threads REQUIRED)
+  find_dependency(Threads)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/PortMidiTargets.cmake")


### PR DESCRIPTION
`find_package(PortMidi)` without `REQUIRED` shall not fail. (Unlikely with Threads, but it is better to use a consistent pattern.)

Amends a47be8c.