### PR TITLE
Fix typoed CMake 'else' branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ option(BUILD_JAVA_NATIVE_INTERFACE
 # and PMWINMM (for windows), but these are assumed.
 #
 if(APPLE OR WIN32)
-else(APPLE_OR_WIN32)
+else(APPLE OR WIN32)
   set(LINUX_DEFINES "PMALSA" CACHE STRING "must define either PMALSA or PMNULL")
   add_compile_definitions(${LINUX_DEFINES})
 endif(APPLE OR WIN32)


### PR DESCRIPTION
The expressions in `else` and `endif` parentheses are not validated and are optional since at least CMake 3.1. So maybe these should be omitted altogether for brevity and fewer typo opportunities?

----

This was originally posted downstream to Debian Salsa: https://salsa.debian.org/debian/portmidi/-/merge_requests/1