### PR TITLE
Fix "Library name" and "Library type" in cmake output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,7 +194,7 @@ install(
 # following report is probably not complete...
 MESSAGE(STATUS "PortMidi Library name: " ${PM_ACTUAL_LIB_NAME})
 MESSAGE(STATUS "Build type: " ${CMAKE_BUILD_TYPE})
-MESSAGE(STATUS "Library Type: " ${LIB_TYPE})
+MESSAGE(STATUS "Build shared library: " ${BUILD_SHARED_LIBS})
 MESSAGE(STATUS "Compiler flags: " ${CMAKE_CXX_COMPILE_FLAGS})
 get_directory_property(prop COMPILE_DEFINITIONS)
 MESSAGE(STATUS "Compile definitions: " ${prop})

--- a/pm_common/CMakeLists.txt
+++ b/pm_common/CMakeLists.txt
@@ -16,9 +16,9 @@
 set(PM_STATIC_LIB_NAME "portmidi" CACHE STRING 
     "For static builds, the PortMidi library name, e.g. portmidi-static.
      Default is portmidi")
-set(PM_ACTUAL_LIB_NAME "portmidi")
+set(PM_ACTUAL_LIB_NAME "portmidi" PARENT_SCOPE)
 if(NOT BUILD_SHARED_LIBS)
-  set(PM_ACTUAL_LIB_NAME ${PM_STATIC_LIB_NAME})
+  set(PM_ACTUAL_LIB_NAME ${PM_STATIC_LIB_NAME} PARENT_SCOPE)
 endif()
 
 # set the build directory for libportmidi.a to be in portmidi, not in 


### PR DESCRIPTION
Before:
```
...
-- PortMidi Library name:
-- Build type: Release
-- Library Type:
...
```

After:
```
...
-- PortMidi Library name: portmidi
-- Build type: Release
-- Build shared library: ON
...
```