### PR TITLE
Add "Doxyfile" to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,8 @@ cmake_install.cmake
 /pm_test/pmlist
 /pm_test/pmlist.dir/
 
+/Doxyfile
+
 /CMakeDoxyfile.in
 
 /CMakeDoxygenDefaults.cmake


### PR DESCRIPTION
Doxyfile is generated from Doxyfile.in and is not in the repository.


In my opinion it's better to do out-of-source builds and just have `/build` in .gitignore.
The build instructions in README.md could be changed to something like this:

mkdir build
cd build
cmake ..
cmake --build .
cmake --install .
