### PR TITLE
Fix scope of PM_ACTUAL_LIB_NAME

### DIFF
--- a/pm_common/CMakeLists.txt
+++ b/pm_common/CMakeLists.txt
@@ -16,10 +16,11 @@
 set(PM_STATIC_LIB_NAME "portmidi" CACHE STRING 
     "For static builds, the PortMidi library name, e.g. portmidi-static.
      Default is portmidi")
-set(PM_ACTUAL_LIB_NAME "portmidi" PARENT_SCOPE)
+set(PM_ACTUAL_LIB_NAME "portmidi")
 if(NOT BUILD_SHARED_LIBS)
-  set(PM_ACTUAL_LIB_NAME ${PM_STATIC_LIB_NAME} PARENT_SCOPE)
+  set(PM_ACTUAL_LIB_NAME ${PM_STATIC_LIB_NAME})
 endif()
+set(PM_ACTUAL_LIB_NAME ${PM_ACTUAL_LIB_NAME} PARENT_SCOPE)
 
 # set the build directory for libportmidi.a to be in portmidi, not in 
 #    portmidi/pm_common. Must be done here BEFORE add_library below.


### PR DESCRIPTION
Setting an alternative name for the static library via PM_STATIC_LIB_NAME has been broken in commit e878378c0fe31e5c6b25f01dcaee61f76fc21985. 

This change fixes it by setting PM_ACTUAL_LIB_NAME in the current scope AND the parent scope.

It can be tested like this:
```
cmake -DBUILD_SHARED_LIBS=OFF -DPM_STATIC_LIB_NAME=test .
make
```

This should print `PortMidi Library name: test` and  produce `libtest.a`.